### PR TITLE
- Issue #8: Add artifactFilter to prevent inadvertently using the sou…

### DIFF
--- a/aspectj-runner/src/main/scala/kamon/aspectj/sbt/AspectjRunner.scala
+++ b/aspectj-runner/src/main/scala/kamon/aspectj/sbt/AspectjRunner.scala
@@ -52,20 +52,20 @@ object AspectjRunner extends AutoPlugin {
 
   def defaultSettings(currentScope: Configuration): Seq[Setting[_]] = Seq(
     aspectjVersion := AspectjVersion,
-    aspectjWeaver <<= findAspectjWeaver,
-    aspectjRunnerOptions <<= aspectjWeaver map runnerJavaOptions,
-    aspectjOptionalArtifact <<= libraryDependencies map findAspectjArtifact,
-    unmanagedClasspath <<= unmanagedClasspath in currentScope,
-    managedClasspath <<= managedClasspath in currentScope,
-    internalDependencyClasspath <<= internalDependencyClasspath in currentScope,
-    externalDependencyClasspath <<= Classpaths.concat(unmanagedClasspath, managedClasspath),
-    dependencyClasspath <<= Classpaths.concat(internalDependencyClasspath, externalDependencyClasspath),
-    exportedProducts <<= exportedProducts in currentScope,
-    fullClasspath <<= Classpaths.concatDistinct(exportedProducts, dependencyClasspath)
+    aspectjWeaver := findAspectjWeaver.value,
+    aspectjRunnerOptions := (aspectjWeaver map runnerJavaOptions).value,
+    aspectjOptionalArtifact := (libraryDependencies map findAspectjArtifact).value,
+    unmanagedClasspath := (unmanagedClasspath in currentScope).value,
+    managedClasspath := (managedClasspath in currentScope).value,
+    internalDependencyClasspath  := (internalDependencyClasspath in currentScope).value,
+    externalDependencyClasspath := Classpaths.concat(unmanagedClasspath, managedClasspath).value,
+    dependencyClasspath := Classpaths.concat(internalDependencyClasspath, externalDependencyClasspath).value,
+    exportedProducts := (exportedProducts in currentScope).value,
+    fullClasspath := Classpaths.concatDistinct(exportedProducts, dependencyClasspath).value
   )
 
   def runSettings(currentScope: Configuration): Seq[Setting[_]] = Seq(
-    mainClass in run <<= mainClass in run in currentScope,
+    mainClass in run := (mainClass in run in currentScope).value,
     inTask(run)(Seq(r <<= aspectjWeaverRunner)).head,
     run <<= Defaults.runTask(fullClasspath, mainClass in run, r in run),
     runMain <<= Defaults.runMainTask(fullClasspath, r in run)
@@ -73,6 +73,6 @@ object AspectjRunner extends AutoPlugin {
 
   def otherSettings: Seq[Setting[_]] = Seq(
     ivyConfigurations ++= Seq(WeaverCompileConfiguration, WeaverScope),
-    libraryDependencies <++= (aspectjVersion in Runner)(aspectjWeaverDependency),
-    allDependencies <++= aspectjOptionalArtifact in Runner)
+    libraryDependencies ++=  (aspectjVersion in Runner)(aspectjWeaverDependency).value,
+    allDependencies ++= (aspectjOptionalArtifact in Runner).value)
 }

--- a/aspectj-runner/src/main/scala/kamon/aspectj/sbt/runner/Runner.scala
+++ b/aspectj-runner/src/main/scala/kamon/aspectj/sbt/runner/Runner.scala
@@ -25,7 +25,7 @@ object Runner {
 
   import AspectjRunner.AspectjRunnerKeys._
 
-  val AspectjVersion = "1.8.6"
+  val AspectjVersion = "1.8.9"
   val WeaverCompileConfiguration = config("weaver-compile-configuration").extend(Configurations.RuntimeInternal).hide
   val WeaverScope = config("weaver-scope").hide
 

--- a/aspectj-runner/src/main/scala/kamon/aspectj/sbt/runner/Runner.scala
+++ b/aspectj-runner/src/main/scala/kamon/aspectj/sbt/runner/Runner.scala
@@ -32,7 +32,9 @@ object Runner {
   def aspectjWeaverDependency(version: String) = Seq("org.aspectj" % "aspectjweaver" % version % WeaverScope.name)
 
   def findAspectjWeaver: Def.Initialize[Task[Option[File]]] = update map { report ⇒
-    report.matching(moduleFilter(organization = "org.aspectj", name = "aspectjweaver")) headOption
+    report.matching(moduleFilter(organization = "org.aspectj", name = "aspectjweaver")
+      // Make sure to only select binary jars.
+      && artifactFilter(`type` = "jar")) headOption
   }
 
   def findAspectjArtifact(dependencies: Seq[ModuleID]): Seq[ModuleID] = {

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,43 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2015 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+import sbt._
+import sbt.Keys._
+
+import Dependencies._
+
+import Settings._
+
+val noPublishing = Seq(publish := (), publishLocal := (), publishArtifact := false)
+
+lazy val sbtAspectjRunner = Project("sbt-aspectj-runner", file("."))
+  .settings(basicSettings: _*)
+  .settings(formatSettings: _*)
+  .settings(noPublishing: _*)
+  .aggregate(aspectjRunner, aspectjPlayRunner)
+
+lazy val aspectjRunner = Project("aspectj-runner", file("aspectj-runner"))
+  .settings(basicSettings: _*)
+  .settings(formatSettings: _*)
+  .settings(libraryDependencies ++= Seq(aspectjTools))
+
+lazy val aspectjPlayRunner = Project("aspectj-play-runner", file("aspectj-play-runner"))
+  .dependsOn(aspectjRunner)
+  .settings(basicSettings: _*)
+  .settings(formatSettings: _*)
+  .settings(libraryDependencies ++= Seq(aspectjTools, playSbtPlugin))
+
+

--- a/examples/kamon-play/project/build.properties
+++ b/examples/kamon-play/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.13

--- a/examples/ping-pong/build.sbt
+++ b/examples/ping-pong/build.sbt
@@ -15,6 +15,8 @@ libraryDependencies += "io.kamon" %% "kamon-akka" % "0.6.0"
 
 libraryDependencies += "io.kamon" %% "kamon-log-reporter" % "0.6.0"
 
-fork in run := false
+libraryDependencies += "org.aspectj" % "aspectjweaver" % "1.8.6" withSources()
+
+fork in run := true
 
 kamon.aspectj.sbt.AspectjRunner.testSettings

--- a/examples/ping-pong/project/build.properties
+++ b/examples/ping-pong/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.13

--- a/examples/ping-pong/project/plugins.sbt
+++ b/examples/ping-pong/project/plugins.sbt
@@ -3,4 +3,4 @@ logLevel := Level.Warn
 
 resolvers +=  "Kamon Repository Snapshots"  at "http://snapshots.kamon.io"
 
-addSbtPlugin("io.kamon" % "aspectj-runner" % "0.1.3")
+addSbtPlugin("io.kamon" % "aspectj-runner" % "0.1.4")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.13


### PR DESCRIPTION
- Issue #8: Add artifactFilter to prevent inadvertently using the source jar instead of the binary jar for aspectj weaver.
- Bump SBT version to 0.13.13
- Issue #8: Change settings in ping pong example to demonstrate and reproduce the source jar issue.